### PR TITLE
Proof of Concept: Parallel Colection of Lazy Candidates for New Resolver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,9 @@ jobs:
     - env:
       - GROUP=2
       - NEW_RESOLVER=1
+    - env:
+      - GROUP=3
+      - NEW_RESOLVER=1
 
   fast_finish: true
   allow_failures:

--- a/src/pip/_internal/cli/progress_bars.py
+++ b/src/pip/_internal/cli/progress_bars.py
@@ -85,7 +85,8 @@ class InterruptibleMixin(object):
             **kwargs
         )
 
-        if not isinstance(threading.current_thread(), threading._MainThread):
+        if not isinstance(threading.current_thread(),
+                          threading._MainThread):  # type: ignore
             return
         self.original_handler = signal(SIGINT, self.handle_sigint)
 

--- a/src/pip/_internal/resolution/resolvelib/base.py
+++ b/src/pip/_internal/resolution/resolvelib/base.py
@@ -56,3 +56,7 @@ class Candidate(object):
     def get_install_requirement(self):
         # type: () -> Optional[InstallRequirement]
         raise NotImplementedError("Override in subclass")
+
+    def prepare(self):
+        # type: () -> None
+        pass

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -162,7 +162,7 @@ class _InstallRequirementBackedCandidate(Candidate):
         # type: () -> AbstractDistribution
         raise NotImplementedError("Override in subclass")
 
-    def _prepare(self):
+    def prepare(self):
         # type: () -> None
         if self._dist is not None:
             return
@@ -195,7 +195,6 @@ class _InstallRequirementBackedCandidate(Candidate):
     @property
     def dist(self):
         # type: () -> Distribution
-        self._prepare()
         return self._dist
 
     def _get_requires_python_specifier(self):
@@ -224,7 +223,6 @@ class _InstallRequirementBackedCandidate(Candidate):
 
     def get_install_requirement(self):
         # type: () -> Optional[InstallRequirement]
-        self._prepare()
         return self._ireq
 
 

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -417,15 +417,15 @@ class ExtrasCandidate(Candidate):
                 extra
             )
 
+        # Add a dependency on the exact base.
+        yield factory.make_requirement_from_candidate(self.base)
+
         for r in self.base.dist.requires(valid_extras):
             requirement = factory.make_requirement_from_spec_matching_extras(
                 str(r), self.base._ireq, valid_extras,
             )
             if requirement:
                 yield requirement
-
-        # Add a dependency on the exact base.
-        yield factory.make_requirement_from_candidate(self.base)
 
     def get_install_requirement(self):
         # type: () -> Optional[InstallRequirement]

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -347,8 +347,8 @@ class ExtrasCandidate(Candidate):
        to treat it as a separate node in the dependency graph.
     2. When we're getting the candidate's dependencies,
        a) We specify that we want the extra dependencies as well.
-       b) We add a dependency on the base candidate (matching the name and
-          version).  See below for why this is needed.
+       b) We add a dependency on the base candidate.
+          See below for why this is needed.
     3. We return None for the underlying InstallRequirement, as the base
        candidate will provide it, and we don't want to end up with duplicates.
 
@@ -417,7 +417,8 @@ class ExtrasCandidate(Candidate):
                 extra
             )
 
-        # Add a dependency on the exact base.
+        # Add a dependency on the exact base
+        # (See note 2b in the class docstring)
         yield factory.make_requirement_from_candidate(self.base)
 
         for r in self.base.dist.requires(valid_extras):

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -425,11 +425,7 @@ class ExtrasCandidate(Candidate):
                 yield requirement
 
         # Add a dependency on the exact base.
-        # (See note 2b in the class docstring)
-        # FIXME: This does not work if the base candidate is specified by
-        # link, e.g. "pip install .[dev]" will fail.
-        spec = "{}=={}".format(self.base.name, self.base.version)
-        yield factory.make_requirement_from_spec(spec, self.base._ireq)
+        yield factory.make_requirement_from_candidate(self.base)
 
     def get_install_requirement(self):
         # type: () -> Optional[InstallRequirement]

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -187,6 +187,7 @@ class Factory(object):
         return SpecifierRequirement(ireq, factory=self)
 
     def make_requirement_from_candidate(self, candidate):
+        # type: (Candidate) -> ExplicitRequirement
         return ExplicitRequirement(candidate)
 
     def make_requirement_from_spec(self, specifier, comes_from):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -180,11 +180,14 @@ class Factory(object):
             # TODO: Get name and version from ireq, if possible?
             #       Specifically, this might be needed in "name @ URL"
             #       syntax - need to check where that syntax is handled.
-            cand = self._make_candidate_from_link(
+            candidate = self._make_candidate_from_link(
                 ireq.link, extras=set(ireq.extras), parent=ireq,
             )
-            return ExplicitRequirement(cand)
+            return self.make_requirement_from_candidate(candidate)
         return SpecifierRequirement(ireq, factory=self)
+
+    def make_requirement_from_candidate(self, candidate):
+        return ExplicitRequirement(candidate)
 
     def make_requirement_from_spec(self, specifier, comes_from):
         # type: (str, InstallRequirement) -> Requirement

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -4,7 +4,9 @@ from pip._vendor.resolvelib.providers import AbstractProvider
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
 
 if MYPY_CHECK_RUNNING:
-    from typing import Any, Dict, Optional, Sequence, Set, Tuple, Union
+    from typing import (
+        Any, Dict, Iterable, Optional, Sequence, Set, Tuple, Union
+    )
 
     from pip._vendor.packaging.version import _BaseVersion
 
@@ -133,3 +135,8 @@ class PipProvider(AbstractProvider):
         if self._ignore_dependencies:
             return []
         return list(candidate.iter_dependencies())
+
+    def prepare_candidates(self, candidates):
+        # type: (Iterable[Candidate]) -> None
+        for candidate in candidates:
+            candidate.prepare()

--- a/src/pip/_internal/resolution/resolvelib/provider.py
+++ b/src/pip/_internal/resolution/resolvelib/provider.py
@@ -1,4 +1,8 @@
+from multiprocessing.dummy import Pool
+from operator import methodcaller
+
 from pip._vendor.packaging.specifiers import SpecifierSet
+from pip._vendor.requests.adapters import DEFAULT_POOLSIZE
 from pip._vendor.resolvelib.providers import AbstractProvider
 
 from pip._internal.utils.typing import MYPY_CHECK_RUNNING
@@ -138,5 +142,7 @@ class PipProvider(AbstractProvider):
 
     def prepare_candidates(self, candidates):
         # type: (Iterable[Candidate]) -> None
-        for candidate in candidates:
-            candidate.prepare()
+        pool = Pool(DEFAULT_POOLSIZE)
+        pool.map(methodcaller('prepare'), candidates)
+        pool.close()
+        pool.join()

--- a/src/pip/_vendor/resolvelib/providers.py
+++ b/src/pip/_vendor/resolvelib/providers.py
@@ -78,6 +78,10 @@ class AbstractProvider(object):
         """
         raise NotImplementedError
 
+    def prepare_candidates(self, candidates):
+        """Prepare lazily evaluated candidates"""
+        raise NotImplementedError
+
 
 class AbstractResolver(object):
     """The thing that performs the actual resolution work.

--- a/src/pip/_vendor/resolvelib/resolvers.py
+++ b/src/pip/_vendor/resolvelib/resolvers.py
@@ -95,8 +95,10 @@ class Criterion(object):
         return reversed(self.candidates)
 
     @property
-    def prefered_candidate(self):
+    def preferred_candidate(self):
         """The candidate to be tried first."""
+        # XXX: This needs not to be only one, but can be many
+        # depending on the optimization.
         return next(self.iter_candidate())
 
     def iter_parent(self):
@@ -317,7 +319,7 @@ class Resolution(object):
 
             # Prepare candidates.
             self._p.prepare_candidates(
-                next(criterion.iter_candidate())
+                criterion.preferred_candidate
                 for name, criterion in self.unsatisfied_criteria)
 
             # Choose the most preferred unpinned criterion to try.

--- a/tests/functional/test_new_resolver.py
+++ b/tests/functional/test_new_resolver.py
@@ -825,9 +825,7 @@ class TestExtraMerge(object):
     @pytest.mark.parametrize(
         "pkg_builder",
         [
-            pytest.param(
-                _local_with_setup, marks=pytest.mark.xfail(strict=True),
-            ),
+            _local_with_setup,
             _direct_wheel,
             _wheel_from_index,
         ],

--- a/tools/travis/run.sh
+++ b/tools/travis/run.sh
@@ -55,6 +55,10 @@ elif [[ "$GROUP" == "2" ]]; then
     # Separate Job for running integration tests for 'pip install'
     tox -- -m integration -n auto --duration=5 -k "test_install" \
         --use-venv $RESOLVER_SWITCH
+elif [[ "$GROUP" == "3" ]]; then
+    # Separate Job for tests that fail with the new resolver
+    tox -- -m fails_on_new_resolver -n auto --duration=5 \
+        --use-venv $RESOLVER_SWITCH --new-resolver-runtests
 else
     # Non-Testing Jobs should run once
     tox


### PR DESCRIPTION
This is only a proof of concept of how lazy collection of candidates (e.g. I/O stuff) *can* be parallelized.  I realized that I made bunch of unnecessary style change, please bear with it.

### Collect 1st candidate(s) for unpinned criteria every resolution round
This is done by calling a (new) `Provider.prepare_candidates` [before every time we try to pin a criterion](https://github.com/pradyunsg/pip/compare/master...McSinyx:rl-parallel?expand=1#diff-8d147b84831b2cbea2d408b1fb0564a1R318).  This should hook to a `prepare` method from the candidate, which only actually do something the first time it is called. (resolvelib side)

`Provider.prepare_candidates` [takes a iterable of candidates and prepare them](https://github.com/pradyunsg/pip/compare/master...McSinyx:rl-parallel?expand=1#diff-513e3eaad24c8bcfc61ba13dc5ae3c69R143).  We can try to parallel this process if possible.  In addition, the UI (progress bars, etc.) should be handled here. (pip side)

### Candidate preparation
If we're still going with multithreading, the `Candidate.prepare` method should be thread-safe.  By default, it might not need to so anything, e.g. for Python version requirement. (pip side)

I feel that the explanation above is above is a bit incoherent, and if there's any terminology mistake, please correct me.